### PR TITLE
Fix most specs for recent changes

### DIFF
--- a/test/gizzmo_spec.rb
+++ b/test/gizzmo_spec.rb
@@ -13,32 +13,32 @@ describe "gizzmo (cli)" do
   describe "basic manipulation commands" do
     describe "create" do
       it "creates a single shard" do
-        gizzmo "create TestShard localhost/t0_0"
+        gizzmo "create TestShard localhost/t_0_000"
 
-        nameserver_db[:shards].should == [info("localhost", "t0_0", "TestShard")]
+        nameserver_db[:shards].should == [info("localhost", "t_0_000", "TestShard")]
       end
 
       it "creates multiple shards" do
-        gizzmo "create TestShard localhost/t0_0 localhost/t0_1"
+        gizzmo "create TestShard localhost/t_0_000 localhost/t_0_001"
 
-        nameserver_db[:shards].should == [info("localhost", "t0_0", "TestShard"),
-                                          info("localhost", "t0_1", "TestShard")]
+        nameserver_db[:shards].should == [info("localhost", "t_0_000", "TestShard"),
+                                          info("localhost", "t_0_001", "TestShard")]
       end
 
       it "honors source and destination types" do
-        gizzmo "create TestShard -s int -d long localhost/t0_0"
-        gizzmo "create TestShard --source-type=int --destination-type=long localhost/t0_1"
+        gizzmo "create TestShard -s int -d long localhost/t_0_000"
+        gizzmo "create TestShard --source-type=int --destination-type=long localhost/t_0_001"
 
-        nameserver_db[:shards].should == [info("localhost", "t0_0", "TestShard", "int", "long"),
-                                          info("localhost", "t0_1", "TestShard", "int", "long")]
+        nameserver_db[:shards].should == [info("localhost", "t_0_000", "TestShard", "int", "long"),
+                                          info("localhost", "t_0_001", "TestShard", "int", "long")]
       end
     end
 
     describe "delete" do
       it "deletes a shard" do
-        ns.create_shard info("localhost", "t0_0", "TestShard")
+        ns.create_shard info("localhost", "t_0_000", "TestShard")
 
-        gizzmo "delete localhost/t0_0"
+        gizzmo "delete localhost/t_0_000"
 
         nameserver_db[:shards].should == []
       end
@@ -46,112 +46,112 @@ describe "gizzmo (cli)" do
 
     describe "wrap/unwrap" do
       before do
-        ns.create_shard info("localhost", "t0_0", "TestShard")
-        ns.create_shard info("localhost", "t0_0_replicating", "ReplicatingShard")
-        ns.add_link id("localhost", "t0_0_replicating"), id("localhost", "t0_0"), 1
+        ns.create_shard info("localhost", "t_0_000", "TestShard")
+        ns.create_shard info("localhost", "t_0_000_replicating", "ReplicatingShard")
+        ns.add_link id("localhost", "t_0_000_replicating"), id("localhost", "t_0_000"), 1
 
-        gizzmo "wrap BlockedShard localhost/t0_0"
+        gizzmo "wrap BlockedShard localhost/t_0_000"
       end
 
       it "wrap wraps a shard" do
-        nameserver_db[:shards].should == [info("localhost", "t0_0", "TestShard"),
-                                          info("localhost", "t0_0_blocked", "BlockedShard"),
-                                          info("localhost", "t0_0_replicating", "ReplicatingShard")]
+        nameserver_db[:shards].should == [info("localhost", "t_0_000", "TestShard"),
+                                          info("localhost", "t_0_000_blocked", "BlockedShard"),
+                                          info("localhost", "t_0_000_replicating", "ReplicatingShard")]
 
-        nameserver_db[:links].should == [link(id("localhost", "t0_0_blocked"), id("localhost", "t0_0"), 1),
-                                         link(id("localhost", "t0_0_replicating"), id("localhost", "t0_0_blocked"), 1)]
+        nameserver_db[:links].should == [link(id("localhost", "t_0_000_blocked"), id("localhost", "t_0_000"), 1),
+                                         link(id("localhost", "t_0_000_replicating"), id("localhost", "t_0_000_blocked"), 1)]
       end
 
       it "unwrap unwraps a shard" do
-        gizzmo "unwrap localhost/t0_0_blocked"
+        gizzmo "unwrap localhost/t_0_000_blocked"
 
-        nameserver_db[:shards].should == [info("localhost", "t0_0", "TestShard"),
-                                          info("localhost", "t0_0_replicating", "ReplicatingShard")]
+        nameserver_db[:shards].should == [info("localhost", "t_0_000", "TestShard"),
+                                          info("localhost", "t_0_000_replicating", "ReplicatingShard")]
 
-        nameserver_db[:links].should == [link(id("localhost", "t0_0_replicating"), id("localhost", "t0_0"), 1)]
+        nameserver_db[:links].should == [link(id("localhost", "t_0_000_replicating"), id("localhost", "t_0_000"), 1)]
       end
 
       it "unwrap doesn't unwrap a top level shard or a leaf" do
-        gizzmo "unwrap localhost/t0_0"
-        gizzmo "unwrap localhost/t0_0_replicating"
+        gizzmo "unwrap localhost/t_0_000"
+        gizzmo "unwrap localhost/t_0_000_replicating"
 
-        nameserver_db[:shards].should == [info("localhost", "t0_0", "TestShard"),
-                                          info("localhost", "t0_0_blocked", "BlockedShard"),
-                                          info("localhost", "t0_0_replicating", "ReplicatingShard")]
+        nameserver_db[:shards].should == [info("localhost", "t_0_000", "TestShard"),
+                                          info("localhost", "t_0_000_blocked", "BlockedShard"),
+                                          info("localhost", "t_0_000_replicating", "ReplicatingShard")]
 
-        nameserver_db[:links].should == [link(id("localhost", "t0_0_blocked"), id("localhost", "t0_0"), 1),
-                                         link(id("localhost", "t0_0_replicating"), id("localhost", "t0_0_blocked"), 1)]
+        nameserver_db[:links].should == [link(id("localhost", "t_0_000_blocked"), id("localhost", "t_0_000"), 1),
+                                         link(id("localhost", "t_0_000_replicating"), id("localhost", "t_0_000_blocked"), 1)]
       end
     end
 
     describe "markbusy" do
       it "marks shards busy" do
-        ns.create_shard info("localhost", "t0_0", "TestShard")
+        ns.create_shard info("localhost", "t_0_000", "TestShard")
 
-        gizzmo "markbusy localhost/t0_0"
+        gizzmo "markbusy localhost/t_0_000"
 
-        nameserver_db[:shards].should == [info("localhost", "t0_0", "TestShard", "", "", 1)]
+        nameserver_db[:shards].should == [info("localhost", "t_0_000", "TestShard", "", "", 1)]
       end
     end
 
     describe "markunbusy" do
       it "marks shards as not busy" do
-        ns.create_shard info("localhost", "t0_0", "TestShard")
-        gizzmo "markbusy localhost/t0_0"
+        ns.create_shard info("localhost", "t_0_000", "TestShard")
+        gizzmo "markbusy localhost/t_0_000"
 
-        gizzmo "markunbusy localhost/t0_0"
+        gizzmo "markunbusy localhost/t_0_000"
 
-        nameserver_db[:shards].should == [info("localhost", "t0_0", "TestShard", "", "", 0)]
+        nameserver_db[:shards].should == [info("localhost", "t_0_000", "TestShard", "", "", 0)]
       end
     end
 
     describe "addforwarding" do
       it "adds a forwarding" do
-        ns.create_shard info("localhost", "t0_0", "TestShard")
+        ns.create_shard info("localhost", "t_0_000", "TestShard")
 
-        gizzmo "addforwarding 0 0 localhost/t0_0"
+        gizzmo "addforwarding 0 0 localhost/t_0_000"
 
-        nameserver_db[:shards].should      == [info("localhost", "t0_0", "TestShard")]
-        nameserver_db[:forwardings].should == [forwarding(0, 0, id("localhost", "t0_0"))]
+        nameserver_db[:shards].should      == [info("localhost", "t_0_000", "TestShard")]
+        nameserver_db[:forwardings].should == [forwarding(0, 0, id("localhost", "t_0_000"))]
       end
     end
 
     describe "deleteforwarding" do
       it "removes a forwarding" do
-        ns.create_shard info("localhost", "t0_0", "TestShard")
+        ns.create_shard info("localhost", "t_0_000", "TestShard")
 
-        gizzmo "addforwarding 0 0 localhost/t0_0"
-        gizzmo "deleteforwarding 0 0 localhost/t0_0"
+        gizzmo "addforwarding 0 0 localhost/t_0_000"
+        gizzmo "deleteforwarding 0 0 localhost/t_0_000"
 
-        nameserver_db[:shards].should      == [info("localhost", "t0_0", "TestShard")]
+        nameserver_db[:shards].should      == [info("localhost", "t_0_000", "TestShard")]
         nameserver_db[:forwardings].should == []
       end
     end
 
     describe "addlink" do
       it "links two shards" do
-        ns.create_shard info("localhost", "t0_0", "TestShard")
-        ns.create_shard info("localhost", "t0_0_replicating", "ReplicatingShard")
+        ns.create_shard info("localhost", "t_0_000", "TestShard")
+        ns.create_shard info("localhost", "t_0_000_replicating", "ReplicatingShard")
 
-        gizzmo "addlink localhost/t0_0_replicating localhost/t0_0 1"
+        gizzmo "addlink localhost/t_0_000_replicating localhost/t_0_000 1"
 
-        nameserver_db[:shards].should == [info("localhost", "t0_0", "TestShard"),
-                                          info("localhost", "t0_0_replicating", "ReplicatingShard")]
+        nameserver_db[:shards].should == [info("localhost", "t_0_000", "TestShard"),
+                                          info("localhost", "t_0_000_replicating", "ReplicatingShard")]
 
-        nameserver_db[:links].should == [link(id("localhost", "t0_0_replicating"), id("localhost", "t0_0"), 1)]
+        nameserver_db[:links].should == [link(id("localhost", "t_0_000_replicating"), id("localhost", "t_0_000"), 1)]
       end
     end
 
     describe "unlink" do
       it "unlinks two shards" do
-        ns.create_shard info("localhost", "t0_0", "TestShard")
-        ns.create_shard info("localhost", "t0_0_replicating", "ReplicatingShard")
+        ns.create_shard info("localhost", "t_0_000", "TestShard")
+        ns.create_shard info("localhost", "t_0_000_replicating", "ReplicatingShard")
 
-        gizzmo "addlink localhost/t0_0_replicating localhost/t0_0 1"
-        gizzmo "unlink localhost/t0_0_replicating localhost/t0_0"
+        gizzmo "addlink localhost/t_0_000_replicating localhost/t_0_000 1"
+        gizzmo "unlink localhost/t_0_000_replicating localhost/t_0_000"
 
-        nameserver_db[:shards].should == [info("localhost", "t0_0", "TestShard"),
-                                          info("localhost", "t0_0_replicating", "ReplicatingShard")]
+        nameserver_db[:shards].should == [info("localhost", "t_0_000", "TestShard"),
+                                          info("localhost", "t_0_000_replicating", "ReplicatingShard")]
 
         nameserver_db[:links].should == []
       end
@@ -182,21 +182,21 @@ describe "gizzmo (cli)" do
   describe "basic read methods" do
     before do
       3.times do |i|
-        ns.create_shard info("localhost", "t0_#{i}_a", "TestShard", "Int", "Int")
-        ns.create_shard info("127.0.0.1", "t0_#{i}_b", "TestShard", "Int", "Int")
-        ns.create_shard info("localhost", "t0_#{i}_replicating", "ReplicatingShard")
-        ns.add_link id("localhost", "t0_#{i}_replicating"), id("localhost", "t0_#{i}_a"), 1
-        ns.add_link id("localhost", "t0_#{i}_replicating"), id("127.0.0.1", "t0_#{i}_b"), 1
-        ns.set_forwarding forwarding(0, i, id("localhost", "t0_#{i}_replicating"))
+        ns.create_shard info("localhost", "t_0_00#{i}_a", "TestShard", "Int", "Int")
+        ns.create_shard info("127.0.0.1", "t_0_00#{i}_b", "TestShard", "Int", "Int")
+        ns.create_shard info("localhost", "t_0_00#{i}_replicating", "ReplicatingShard")
+        ns.add_link id("localhost", "t_0_00#{i}_replicating"), id("localhost", "t_0_00#{i}_a"), 1
+        ns.add_link id("localhost", "t_0_00#{i}_replicating"), id("127.0.0.1", "t_0_00#{i}_b"), 1
+        ns.set_forwarding forwarding(0, i, id("localhost", "t_0_00#{i}_replicating"))
       end
     end
 
     describe "subtree" do
       it "prints the tree for a shard" do
-        results = "localhost/t0_0_replicating\n  127.0.0.1/t0_0_b\n  localhost/t0_0_a\n"
-        gizzmo("subtree localhost/t0_0_replicating").should == results
-        gizzmo("subtree localhost/t0_0_a").should == results
-        gizzmo("subtree 127.0.0.1/t0_0_b").should == results
+        results = "localhost/t_0_000_replicating\n  127.0.0.1/t_0_000_b\n  localhost/t_0_000_a\n"
+        gizzmo("subtree localhost/t_0_000_replicating").should == results
+        gizzmo("subtree localhost/t_0_000_a").should == results
+        gizzmo("subtree 127.0.0.1/t_0_000_b").should == results
       end
     end
 
@@ -215,40 +215,40 @@ describe "gizzmo (cli)" do
     describe "forwardings" do
       it "lists forwardings and the root of the corresponding shard trees" do
         gizzmo("forwardings").should == <<-EOF
-0\t0\tlocalhost/t0_0_replicating
-0\t1\tlocalhost/t0_1_replicating
-0\t2\tlocalhost/t0_2_replicating
+0\t0\tlocalhost/t_0_000_replicating
+0\t1\tlocalhost/t_0_001_replicating
+0\t2\tlocalhost/t_0_002_replicating
         EOF
       end
     end
 
     describe "links" do
       it "lists links associated withe the given shards" do
-        gizzmo("links localhost/t0_0_a localhost/t0_1_a").should == <<-EOF
-localhost/t0_0_replicating\tlocalhost/t0_0_a\t1
-localhost/t0_1_replicating\tlocalhost/t0_1_a\t1
+        gizzmo("links localhost/t_0_000_a localhost/t_0_001_a").should == <<-EOF
+localhost/t_0_000_replicating\tlocalhost/t_0_000_a\t1
+localhost/t_0_001_replicating\tlocalhost/t_0_001_a\t1
         EOF
       end
     end
 
     describe "info" do
       it "outputs shard info for the given shard ids" do
-        gizzmo("info localhost/t0_0_a 127.0.0.1/t0_1_b localhost/t0_2_replicating").should == <<-EOF
-localhost/t0_0_a\tTestShard\tok
-127.0.0.1/t0_1_b\tTestShard\tok
-localhost/t0_2_replicating\tReplicatingShard\tok
+        gizzmo("info localhost/t_0_000_a 127.0.0.1/t_0_001_b localhost/t_0_002_replicating").should == <<-EOF
+localhost/t_0_000_a\tTestShard\tok
+127.0.0.1/t_0_001_b\tTestShard\tok
+localhost/t_0_002_replicating\tReplicatingShard\tok
         EOF
       end
     end
 
     describe "busy" do
       it "lists all busy shards" do
-        gizzmo "markbusy localhost/t0_0_a localhost/t0_1_a localhost/t0_2_a"
+        gizzmo "markbusy localhost/t_0_000_a localhost/t_0_001_a localhost/t_0_002_a"
 
         gizzmo("busy").should == <<-EOF
-localhost/t0_0_a\tTestShard\tbusy
-localhost/t0_1_a\tTestShard\tbusy
-localhost/t0_2_a\tTestShard\tbusy
+localhost/t_0_000_a\tTestShard\tbusy
+localhost/t_0_001_a\tTestShard\tbusy
+localhost/t_0_002_a\tTestShard\tbusy
         EOF
       end
     end
@@ -274,17 +274,17 @@ c2:c2host2:7777 0
 
       it "shows the template for each forwarding" do
         gizzmo("-T 0 topology --forwardings").should == <<-EOF
-[0] 0 = localhost/t0_0_replicating	ReplicatingShard(1) -> (TestShard(localhost,1,Int,Int), TestShard(127.0.0.1,1,Int,Int))
-[0] 1 = localhost/t0_1_replicating	ReplicatingShard(1) -> (TestShard(localhost,1,Int,Int), TestShard(127.0.0.1,1,Int,Int))
-[0] 2 = localhost/t0_2_replicating	ReplicatingShard(1) -> (TestShard(localhost,1,Int,Int), TestShard(127.0.0.1,1,Int,Int))
+[0] 0 = localhost/t_0_000_replicating	ReplicatingShard(1) -> (TestShard(localhost,1,Int,Int), TestShard(127.0.0.1,1,Int,Int))
+[0] 1 = localhost/t_0_001_replicating	ReplicatingShard(1) -> (TestShard(localhost,1,Int,Int), TestShard(127.0.0.1,1,Int,Int))
+[0] 2 = localhost/t_0_002_replicating	ReplicatingShard(1) -> (TestShard(localhost,1,Int,Int), TestShard(127.0.0.1,1,Int,Int))
         EOF
       end
 
       it "shows the template for each root shard" do
         gizzmo("-T 0 topology --shards").should == <<-EOF
-localhost/t0_0_replicating	ReplicatingShard(1) -> (TestShard(localhost,1,Int,Int), TestShard(127.0.0.1,1,Int,Int))
-localhost/t0_1_replicating	ReplicatingShard(1) -> (TestShard(localhost,1,Int,Int), TestShard(127.0.0.1,1,Int,Int))
-localhost/t0_2_replicating	ReplicatingShard(1) -> (TestShard(localhost,1,Int,Int), TestShard(127.0.0.1,1,Int,Int))
+localhost/t_0_000_replicating	ReplicatingShard(1) -> (TestShard(localhost,1,Int,Int), TestShard(127.0.0.1,1,Int,Int))
+localhost/t_0_001_replicating	ReplicatingShard(1) -> (TestShard(localhost,1,Int,Int), TestShard(127.0.0.1,1,Int,Int))
+localhost/t_0_002_replicating	ReplicatingShard(1) -> (TestShard(localhost,1,Int,Int), TestShard(127.0.0.1,1,Int,Int))
         EOF
       end
     end


### PR DESCRIPTION
Make shard ids used in tests conform to the new validation (which we confirmed was already required for the shard to be transformed), and set up an empty_ops map to satisfy equality in the transform tests.
