### PR TITLE
DS-46: Improve rebalance scheduling time

### DIFF
--- a/lib/gizzard/rebalancer.rb
+++ b/lib/gizzard/rebalancer.rb
@@ -12,7 +12,6 @@ module Gizzard
       # removes n 'random' elements without set lookups
       def take!(n)
         removed = []
-        inn = n
         set.reject! do |e|
           if (n = n-1) >= 0
             # remove first n elements

--- a/lib/gizzard/rebalancer.rb
+++ b/lib/gizzard/rebalancer.rb
@@ -88,9 +88,9 @@ module Gizzard
 
     def rebalance!
       count = 0
-      while bucket_disparity(ordered = ordered_buckets) > 1
-        dest_bucket = ordered.first
-        src_bucket = ordered.last
+      while bucket_disparity(min_and_max = min_and_max_buckets) > 1
+        dest_bucket = min_and_max.first
+        src_bucket = min_and_max.last
         move_shard! src_bucket, dest_bucket
       end
     end
@@ -115,9 +115,9 @@ module Gizzard
       @transformations
     end
 
-    def ordered_buckets
-      # TODO: re-sorting the buckets every time is a waste, but usually there are only a few dozen buckets
-      @result.sort_by {|bucket| bucket.balance }
+    # a tuple of the minimum and maximum buckets (which might be the same bucket)
+    def min_and_max_buckets
+      @result.minmax_by {|bucket| bucket.balance }
     end
 
     def memoized_concrete_descendants(t)
@@ -125,8 +125,8 @@ module Gizzard
       @memoized_concrete_descendants[t] ||= t.concrete_descendants
     end
 
-    def bucket_disparity(ordered)
-      ordered.last.balance - ordered.first.balance
+    def bucket_disparity(min_and_max)
+      min_and_max.last.balance - min_and_max.first.balance
     end
 
     def move_shard!(src_bucket, dest_bucket)

--- a/lib/gizzard/shard_template.rb
+++ b/lib/gizzard/shard_template.rb
@@ -99,13 +99,12 @@ module Gizzard
     def <=>(other)
       raise ArgumentError, "other is not a ShardTemplate" unless other.is_a? ShardTemplate
 
-      to_a = lambda {|t| [t.host, t.type, t.source_type.to_s, t.dest_type.to_s, t.weight] }
-
-      if (cmp = to_a.call(self) <=> to_a.call(other)) == 0
-        children <=> other.children
-      else
-        cmp
-      end
+      if ((cmp = self.host <=> other.host) != 0); return cmp end
+      if ((cmp = self.type <=> other.type) != 0); return cmp end
+      if ((cmp = self.source_type.to_s <=> other.source_type.to_s) != 0); return cmp end
+      if ((cmp = self.dest_type.to_s <=> other.dest_type.to_s) != 0); return cmp end
+      if ((cmp = self.weight <=> other.weight) != 0); return cmp end
+      return self.children <=> other.children
     end
 
     def eql?(other)
@@ -144,7 +143,8 @@ module Gizzard
     end
 
     def hash
-      weight.hash + host.hash + type.hash + children.hash
+      return @hash if @hash
+      @hash = weight.hash + host.hash + type.hash + children.hash
     end
 
 

--- a/lib/gizzard/shard_template.rb
+++ b/lib/gizzard/shard_template.rb
@@ -12,22 +12,31 @@ module Gizzard
     def initialize(type, host, weight, source_type, dest_type, children)
       @type, @host, @weight, @source_type, @dest_type, @children =
         type, host, weight, source_type || '', dest_type || '', children
+      @type_name = ShardTemplate.type_to_type_name(type)
+    end
+
+    def self.type_to_type_name(type)
+      if (dot_index = type.rindex('.'))
+        type[dot_index+1 .. -1]
+      else
+        type
+      end
     end
 
     def self.concrete?(type)
-      !Shard::VIRTUAL_SHARD_TYPES.include? type.split('.').last
+      !Shard::VIRTUAL_SHARD_TYPES.include?(type_to_type_name(type))
     end
 
     def concrete?
-      self.class.concrete? type
+      !Shard::VIRTUAL_SHARD_TYPES.include? @type_name
     end
 
     def replicating?
-      Shard::REPLICATING_SHARD_TYPES.include? type.split('.').last
+      Shard::REPLICATING_SHARD_TYPES.include? @type_name
     end
 
     def valid_copy_source?
-      !Shard::INVALID_COPY_TYPES.include? type.split('.').last
+      !Shard::INVALID_COPY_TYPES.include? @type_name
     end
 
     def identifier
@@ -35,11 +44,11 @@ module Gizzard
     end
 
     def table_name_suffix
-      Shard::SHARD_SUFFIXES[type.split('.').last]
+      Shard::SHARD_SUFFIXES[@type_name]
     end
 
     def shard_tag
-      Shard::SHARD_TAGS[type.split('.').last]
+      Shard::SHARD_TAGS[@type_name]
     end
 
     def host

--- a/lib/gizzard/shard_template.rb
+++ b/lib/gizzard/shard_template.rb
@@ -152,8 +152,7 @@ module Gizzard
     end
 
     def hash
-      return @hash if @hash
-      @hash = weight.hash + host.hash + type.hash + children.hash
+      weight.hash + host.hash + type.hash + children.hash
     end
 
 

--- a/lib/gizzard/transformation.rb
+++ b/lib/gizzard/transformation.rb
@@ -82,20 +82,18 @@ module Gizzard
     end
 
     def eql?(o)
-      o.is_a?(self.class) &&
-      from.eql?(o.from) &&
-      to.eql?(o.to) &&
-      copy_dest_wrapper.eql?(o.copy_dest_wrapper)
+      o.is_a?(self.class) && (self <=> o) == 0
     end
 
     def <=>(o)
-      to_a = lambda {|t| [t.from, t.to, t.copy_dest_wrapper] }
-
-      to_a.call(self) <=> to_a.call(o)
+      if ((cmp = self.from <=> o.from) != 0); return cmp end
+      if ((cmp = self.to <=> o.to) != 0); return cmp end
+      self.copy_dest_wrapper <=> o.copy_dest_wrapper
     end
 
     def hash
-      from.hash + to.hash + copy_dest_wrapper.hash
+      return @hash if @hash
+      @hash = from.hash + to.hash + copy_dest_wrapper.hash
     end
 
     # create a map of empty phase lists


### PR DESCRIPTION
> Gizzmo seems to have some algorithmic inefficiencies in scheduling especially rebalance operations which make it impossible to rebalance [clusters with many shards]

This pull tries to cut down on object creation in comparisons, and memoizes hash codes and other expensive-to-compute values. It also makes changes to bucket balancing: moving multiple shards per rebalance iteration, and attempting to minimize set/map lookups.

For a test case with 10k shards, 10 initial hosts, and 16 destination hosts:
117 seconds pre-patch
7 seconds post-patch
